### PR TITLE
fixes #12 cloudwatch metastore metrics reporter

### DIFF
--- a/apiary-metastore-metrics/README.md
+++ b/apiary-metastore-metrics/README.md
@@ -1,0 +1,22 @@
+# Apiary Metastore metrics reporter
+
+## Overview
+The metrics reporter is an optional Apiary component which, if enabled, will push metastore metrics to cloudwatch.
+
+## Installation
+The reporter can be activated by placing its jar file on the Hive metastore classpath and configuring Hive accordingly. For Apiary 
+this is done in [apiary-metastore-docker](https://github.com/ExpediaInc/apiary-metastore-docker). 
+
+## Configuration
+The cloudwatch reporter can be configured by setting the following System Environment variables:
+
+|Environment Variable|Required|Description|
+|----|----|----|
+CLOUDWATCH_NAMESPACE|Yes|Custom namespace for metastore cloudwatch metrics.
+ECS_TASK_ID|Yes|ecsTaskId dimension added to cloudwatch metrics to identify metastore container.
+
+# Legal
+This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Copyright 2018 Expedia Inc.
+

--- a/apiary-metastore-metrics/README.md
+++ b/apiary-metastore-metrics/README.md
@@ -4,11 +4,11 @@
 The metrics reporter is an optional Apiary component which, if enabled, will push metastore metrics to cloudwatch.
 
 ## Installation
-The reporter can be activated by placing its jar file on the Hive metastore classpath and configuring Hive accordingly. For Apiary 
+The metrics reporter can be activated by placing its jar file on the Hive metastore classpath and configuring Hive accordingly. For Apiary 
 this is done in [apiary-metastore-docker](https://github.com/ExpediaInc/apiary-metastore-docker). 
 
 ## Configuration
-The cloudwatch reporter can be configured by setting the following System Environment variables:
+The metrics reporter can be configured by setting the following System Environment variables:
 
 |Environment Variable|Required|Description|
 |----|----|----|

--- a/apiary-metastore-metrics/README.md
+++ b/apiary-metastore-metrics/README.md
@@ -1,7 +1,7 @@
 # Apiary Metastore metrics reporter
 
 ## Overview
-The metrics reporter is an optional Apiary component which, if enabled, will push metastore metrics to cloudwatch.
+The metrics reporter is an optional Apiary component which, if enabled, will push metastore metrics to CloudWatch.
 
 ## Installation
 The metrics reporter can be activated by placing its jar file on the Hive metastore classpath and configuring Hive accordingly. For Apiary 
@@ -12,8 +12,8 @@ The metrics reporter can be configured by setting the following System Environme
 
 |Environment Variable|Required|Description|
 |----|----|----|
-CLOUDWATCH_NAMESPACE|Yes|Custom namespace for metastore cloudwatch metrics.
-ECS_TASK_ID|Yes|ecsTaskId dimension added to cloudwatch metrics to identify metastore container.
+CLOUDWATCH_NAMESPACE|Yes|Custom namespace for metastore CloudWatch metrics.
+ECS_TASK_ID|Yes|ECS task ID dimension added to CloudWatch metrics to identify metastore container.
 
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>apiary-metastore-metrics</artifactId>
   <name>Apiary Metastore Metrics</name>
-  <description>Codahale reporter to send Hive Metastore metrics to cloudwatch</description>
+  <description>Codahale reporter to send Hive Metastore metrics to CloudWatch</description>
 
   <dependencies>
     <dependency>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -17,17 +17,6 @@
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tdunning</groupId>
-      <artifactId>json</artifactId>
-      <version>1.8</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -73,29 +62,12 @@
                 <includes>
                   <include>com.amazonaws:*</include>
                   <include>com.expedia.apiary:*</include>
-                  <include>com.fasterxml.jackson.*:*</include>
-                  <include>com.tdunning:json</include>
-                  <include>org.apache.httpcomponents:*</include>
                 </includes>
               </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.amazonaws</pattern>
                   <shadedPattern>${shade.prefix}.com.amazonaws</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <!-- Note org.apache.httpcomponents groupId but org.apache.http package, this is relocated due
-                    to newer version used by com.amazonaws, older version is provided by /usr/lib/hive/ -->
-                  <pattern>org.apache.http</pattern>
-                  <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.json</pattern>
-                  <shadedPattern>${shade.prefix}.org.json</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -34,6 +36,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -73,16 +81,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <environmentVariables>
-            <CLOUDWATCH_NAMESPACE>apiary-test-metastore</CLOUDWATCH_NAMESPACE>
-            <ECS_TASK_ID>43e876c3-adf0-4089-9039-e318e2da9bdb</ECS_TASK_ID>
-          </environmentVariables>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -74,6 +74,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <environmentVariables>
+            <CLOUDWATCH_NAMESPACE>apiary-test-metastore</CLOUDWATCH_NAMESPACE>
+            <ECS_TASK_ID>43e876c3-adf0-4089-9039-e318e2da9bdb</ECS_TASK_ID>
+          </environmentVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.expedia.apiary</groupId>
+    <artifactId>apiary-extensions-parent</artifactId>
+    <version>0.1.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>apiary-metastore-metrics</artifactId>
+  <name>Apiary Metastore Metrics</name>
+  <description>Codahale reporter to send Hive Metastore metrics to cloudwatch</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-cloudwatch</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>json</artifactId>
+      <version>1.8</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>${hive.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>all</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <include>com.amazonaws:*</include>
+                  <include>com.expedia.apiary:*</include>
+                  <include>com.fasterxml.jackson.*:*</include>
+                  <include>com.tdunning:json</include>
+                  <include>org.apache.httpcomponents:*</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.amazonaws</pattern>
+                  <shadedPattern>${shade.prefix}.com.amazonaws</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <!-- Note org.apache.httpcomponents groupId but org.apache.http package, this is relocated due
+                    to newer version used by com.amazonaws, older version is provided by /usr/lib/hive/ -->
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json</pattern>
+                  <shadedPattern>${shade.prefix}.org.json</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
@@ -15,81 +15,80 @@
  */
 package com.expedia.apiary.extensions.metastore.metrics;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Gauge;
-
 import java.io.Closeable;
-import java.util.TimerTask;
-import java.util.List;
 import java.util.Map;
 import java.util.Timer;
+import java.util.TimerTask;
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
-import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 
 /**
- * TODO: need to update this to implement CodahaleReporter when migrating to hive 3.0.0, 
- * similar to https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/JsonFileMetricsReporter.java
+ * TODO: need to update this to implement CodahaleReporter when migrating to Hive 3.0.0, similar to
+ * https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/JsonFileMetricsReporter.java
  */
-
 class CloudwatchReporter implements Closeable {
-    private Timer timer = null;
-    private AmazonCloudWatch cloudWatch = null;
-    private MetricRegistry metricRegistry;
+  private Timer timer = null;
+  private AmazonCloudWatch cloudWatch = null;
+  private MetricRegistry metricRegistry;
 
-    private String namespace = null;
-    private String taskId = null;
+  private String namespace = null;
+  private String taskId = null;
 
-    public CloudwatchReporter(MetricRegistry metricRegistry) {
-        this.metricRegistry=metricRegistry;
-        this.cloudWatch = AmazonCloudWatchClientBuilder.defaultClient();
-        this.timer = new Timer(true);
-
-        this.namespace = System.getenv("CLOUDWATCH_NAMESPACE");
-        if(namespace==null||namespace.equals("")) throw new IllegalArgumentException("CLOUDWATCH_NAMESPACE System envrionment variable not defined");
-
-        this.taskId = System.getenv("ECS_TASK_ID");
-        if(taskId==null||taskId.equals("")) throw new IllegalArgumentException("ECS_TASK_ID System envrionment variable not defined");
+  public CloudwatchReporter(MetricRegistry metricRegistry) {
+    namespace = System.getenv("CLOUDWATCH_NAMESPACE");
+    if (namespace == null || namespace.equals("")) {
+      throw new IllegalArgumentException(
+          "CLOUDWATCH_NAMESPACE System envrionment variable not defined");
     }
 
-    public void start() {
-      timer.schedule(new TimerTask() {
-        @Override
-        public void run() {
-            Dimension dimension = new Dimension().withName("ecsTaskId").withValue(taskId);
-            //all interested metrics are gauges so only writing those to cloudwatch
-            for (Map.Entry<String,Gauge> entry : metricRegistry.getGauges().entrySet()) {
-                String metricName = entry.getKey();
-                Double metricValue = null;
-                if(entry.getValue().getValue() instanceof Long)
-                {
-                    metricValue = ((Long)(entry.getValue().getValue())).doubleValue();
-                }
-                else if(entry.getValue().getValue() instanceof Integer)
-                {
-                    metricValue = ((Integer)(entry.getValue().getValue())).doubleValue();
-                }
-                if(metricValue != null)
-                {
-                    MetricDatum datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
-                    PutMetricDataRequest request = new PutMetricDataRequest().withNamespace(namespace) .withMetricData(datum);
-                    PutMetricDataResult response = cloudWatch.putMetricData(request);
-                }
-            }
+    taskId = System.getenv("ECS_TASK_ID");
+    if (taskId == null || taskId.equals("")) {
+      throw new IllegalArgumentException("ECS_TASK_ID System envrionment variable not defined");
+    }
+
+    this.metricRegistry = metricRegistry;
+    cloudWatch = AmazonCloudWatchClientBuilder.defaultClient();
+    timer = new Timer(true);
+
+  }
+
+  public void start() {
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        Dimension dimension = new Dimension().withName("ecsTaskId").withValue(taskId);
+        // all interesting metrics for our purposes are gauges so only writing those to CloudWatch
+        for (Map.Entry<String, Gauge> entry : metricRegistry.getGauges().entrySet()) {
+          String metricName = entry.getKey();
+          Double metricValue = null;
+          if (entry.getValue().getValue() instanceof Long) {
+            metricValue = ((Long) (entry.getValue().getValue())).doubleValue();
+          } else if (entry.getValue().getValue() instanceof Integer) {
+            metricValue = ((Integer) (entry.getValue().getValue())).doubleValue();
+          }
+          if (metricValue != null) {
+            MetricDatum datum = new MetricDatum().withMetricName(metricName)
+                .withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
+            PutMetricDataRequest request =
+                new PutMetricDataRequest().withNamespace(namespace).withMetricData(datum);
+            cloudWatch.putMetricData(request);
+          }
         }
-      }, 0, 60000); //write to cloudwatch every minute
-    }
-
-    @Override
-    public void close() {
-      if (timer != null) {
-        this.timer.cancel();
       }
-    }
-}
+    }, 0, 60000); // write to CloudWatch every minute
+  }
 
+  @Override
+  public void close() {
+    if (timer != null) {
+      timer.cancel();
+    }
+  }
+}

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.util.TimerTask;
 import java.util.List;
 import java.util.Map;
+import java.util.Timer;
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
@@ -37,18 +38,17 @@ import com.amazonaws.services.cloudwatch.model.Dimension;
  */
 
 class CloudwatchReporter implements Closeable {
-    private java.util.Timer timer = null;
-    private AmazonCloudWatch cw = null;
+    private Timer timer = null;
+    private AmazonCloudWatch cloudWatch = null;
     private MetricRegistry metricRegistry;
 
     public CloudwatchReporter(MetricRegistry metricRegistry) {
         this.metricRegistry=metricRegistry;
+        this.cloudWatch = AmazonCloudWatchClientBuilder.defaultClient();
+        this.timer = new Timer(true);
     }
 
     public void start() {
-      this.cw = AmazonCloudWatchClientBuilder.defaultClient();
-      this.timer = new java.util.Timer(true);
-
       timer.schedule(new TimerTask() {
         @Override
         public void run() {
@@ -74,7 +74,7 @@ class CloudwatchReporter implements Closeable {
                     }
                     MetricDatum datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
                     PutMetricDataRequest request = new PutMetricDataRequest().withNamespace(namespace) .withMetricData(datum);
-                    PutMetricDataResult response = cw.putMetricData(request);
+                    PutMetricDataResult response = cloudWatch.putMetricData(request);
                 } catch (Exception e) {
                     //ignore threads.deadlocks collection
                 }

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
@@ -64,27 +64,21 @@ class CloudwatchReporter implements Closeable {
             Dimension dimension = new Dimension().withName("ecsTaskId").withValue(taskId);
             //all interested metrics are gauges so only writing those to cloudwatch
             for (Map.Entry<String,Gauge> entry : metricRegistry.getGauges().entrySet()) {
-                try
+                String metricName = entry.getKey();
+                Double metricValue = null;
+                if(entry.getValue().getValue() instanceof Long)
                 {
-                    String metricName = entry.getKey();
-                    Double metricValue;
-                    if(entry.getValue().getValue() instanceof Long)
-                    {
-                        metricValue = ((Long)(entry.getValue().getValue())).doubleValue();
-                    }
-                    else if(entry.getValue().getValue() instanceof Integer)
-                    {
-                        metricValue = ((Integer)(entry.getValue().getValue())).doubleValue();
-                    }
-                    else
-                    {
-                        metricValue = (double)entry.getValue().getValue();
-                    }
+                    metricValue = ((Long)(entry.getValue().getValue())).doubleValue();
+                }
+                else if(entry.getValue().getValue() instanceof Integer)
+                {
+                    metricValue = ((Integer)(entry.getValue().getValue())).doubleValue();
+                }
+                if(metricValue != null)
+                {
                     MetricDatum datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
                     PutMetricDataRequest request = new PutMetricDataRequest().withNamespace(namespace) .withMetricData(datum);
                     PutMetricDataResult response = cloudWatch.putMetricData(request);
-                } catch (Exception e) {
-                    //ignore threads.deadlocks collection
                 }
             }
         }

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CloudwatchReporter.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.apiary.extensions.metastore.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Gauge;
+
+import java.io.Closeable;
+import java.util.TimerTask;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+
+/**
+ * TODO: need to update this to implement CodahaleReporter when migrating to hive 3.0.0, 
+ * similar to https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/JsonFileMetricsReporter.java
+ */
+
+class CloudwatchReporter implements Closeable {
+    private java.util.Timer timer = null;
+    private AmazonCloudWatch cw = null;
+    private MetricRegistry metricRegistry;
+
+    public CloudwatchReporter(MetricRegistry metricRegistry) {
+        this.metricRegistry=metricRegistry;
+    }
+
+    public void start() {
+      this.cw = AmazonCloudWatchClientBuilder.defaultClient();
+      this.timer = new java.util.Timer(true);
+
+      timer.schedule(new TimerTask() {
+        @Override
+        public void run() {
+            String namespace = System.getenv("CLOUDWATCH_NAMESPACE");
+            Dimension dimension = new Dimension().withName("ecsTaskId") .withValue(System.getenv("ECS_TASK_ID"));
+            //all interested metrics are gauges so only writing those to cloudwatch
+            for (Map.Entry<String,Gauge> entry : metricRegistry.getGauges().entrySet()) {
+                try
+                {
+                    String metricName = entry.getKey();
+                    Double metricValue;
+                    if(entry.getValue().getValue() instanceof Long)
+                    {
+                        metricValue = ((Long)(entry.getValue().getValue())).doubleValue();
+                    }
+                    else if(entry.getValue().getValue() instanceof Integer)
+                    {
+                        metricValue = ((Integer)(entry.getValue().getValue())).doubleValue();
+                    }
+                    else
+                    {
+                        metricValue = (double)entry.getValue().getValue();
+                    }
+                    MetricDatum datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
+                    PutMetricDataRequest request = new PutMetricDataRequest().withNamespace(namespace) .withMetricData(datum);
+                    PutMetricDataResult response = cw.putMetricData(request);
+                } catch (Exception e) {
+                    //ignore threads.deadlocks collection
+                }
+            }
+        }
+      }, 0, 60000); //write to cloudwatch every minute
+    }
+
+    @Override
+    public void close() {
+      if (timer != null) {
+        this.timer.cancel();
+      }
+    }
+}
+

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
@@ -15,6 +15,9 @@
  */
 
 /**
+ * copied from https://github.com/apache/hive/blob/branch-2.3/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
+ * replaced initReporting with initCloudwatchReporting
+ *
  * TODO: this class won't be needed with hive 3.0.0 as it supports new property hive.service.metrics.codahale.reporter.classes 
  * https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-Metrics
  */
@@ -211,6 +214,7 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
         }
       }
     }
+    //removed initReporting from original source and added initCloudwatchReporting
     initCloudwatchReporting();
   }
 

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
@@ -15,13 +15,13 @@
  */
 
 /**
- * copied from https://github.com/apache/hive/blob/branch-2.3/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
- * replaced initReporting with initCloudwatchReporting
+ * Contains code from the Apache Hive project, specifically 
+ *    https://github.com/apache/hive/blob/branch-2.3/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
+ * The initReporting() method has been replaced with initCloudwatchReporting() in order to modify the types of Metrics that are output.
  *
- * TODO: this class won't be needed with hive 3.0.0 as it supports new property hive.service.metrics.codahale.reporter.classes 
+ * TODO: This class won't be needed with Hive 3.0.0 as it supports a new property "hive.service.metrics.codahale.reporter.classes" 
  * https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-Metrics
  */
-
 package com.expedia.apiary.extensions.metastore.metrics;
 
 import com.codahale.metrics.ConsoleReporter;

--- a/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
+++ b/apiary-metastore-metrics/src/main/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetrics.java
@@ -1,0 +1,439 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.apiary.extensions.metastore.metrics;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.json.MetricsModule;
+import com.codahale.metrics.jvm.BufferPoolMetricSet;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.joshelser.dropwizard.metrics.hadoop.HadoopMetrics2Reporter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
+import org.apache.hadoop.hive.common.metrics.common.MetricsScope;
+import org.apache.hadoop.hive.common.metrics.common.MetricsVariable;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hadoop.hive.common.metrics.metrics2.MetricsReporting;
+import org.apache.hadoop.hive.common.metrics.metrics2.MetricVariableRatioGauge;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+
+import java.util.SortedMap; 
+
+
+/**
+ * Codahale-backed Metrics implementation.
+ */
+public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.common.Metrics {
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(CodahaleMetrics.class);
+
+  public final MetricRegistry metricRegistry = new MetricRegistry();
+  private final Lock timersLock = new ReentrantLock();
+  private final Lock countersLock = new ReentrantLock();
+  private final Lock gaugesLock = new ReentrantLock();
+  private final Lock metersLock = new ReentrantLock();
+
+  private LoadingCache<String, Timer> timers;
+  private LoadingCache<String, Counter> counters;
+  private LoadingCache<String, Meter> meters;
+  private ConcurrentHashMap<String, Gauge> gauges;
+
+  private HiveConf conf;
+  private final Set<Closeable> reporters = new HashSet<Closeable>();
+
+  private final ThreadLocal<HashMap<String, CodahaleMetricsScope>> threadLocalScopes
+    = new ThreadLocal<HashMap<String, CodahaleMetricsScope>>() {
+    @Override
+    protected HashMap<String, CodahaleMetricsScope> initialValue() {
+      return new HashMap<String, CodahaleMetricsScope>();
+    }
+  };
+
+  public class CodahaleMetricsScope implements MetricsScope {
+
+    private final String name;
+    private final Timer timer;
+    private Timer.Context timerContext;
+
+    private boolean isOpen = false;
+
+    /**
+     * Instantiates a named scope - intended to only be called by Metrics, so locally scoped.
+     * @param name - name of the variable
+     */
+    private CodahaleMetricsScope(String name) {
+      this.name = name;
+      this.timer = CodahaleMetrics.this.getTimer(name);
+      open();
+    }
+
+    /**
+     * Opens scope, and makes note of the time started, increments run counter
+     *
+     */
+    public void open() {
+      if (!isOpen) {
+        isOpen = true;
+        this.timerContext = timer.time();
+        CodahaleMetrics.this.incrementCounter(MetricsConstant.ACTIVE_CALLS + name);
+      } else {
+        LOGGER.warn("Scope named " + name + " is not closed, cannot be opened.");
+      }
+    }
+
+    /**
+     * Closes scope, and records the time taken
+     */
+    public void close() {
+      if (isOpen) {
+        timerContext.close();
+        CodahaleMetrics.this.decrementCounter(MetricsConstant.ACTIVE_CALLS + name);
+      } else {
+        LOGGER.warn("Scope named " + name + " is not open, cannot be closed.");
+      }
+      isOpen = false;
+    }
+  }
+
+  public CodahaleMetrics(HiveConf conf) {
+    this.conf = conf;
+    //Codahale artifacts are lazily-created.
+    timers = CacheBuilder.newBuilder().build(
+      new CacheLoader<String, com.codahale.metrics.Timer>() {
+        @Override
+        public com.codahale.metrics.Timer load(String key) {
+          Timer timer = new Timer(new ExponentiallyDecayingReservoir());
+          metricRegistry.register(key, timer);
+          return timer;
+        }
+      }
+    );
+    counters = CacheBuilder.newBuilder().build(
+      new CacheLoader<String, Counter>() {
+        @Override
+        public Counter load(String key) {
+          Counter counter = new Counter();
+          metricRegistry.register(key, counter);
+          return counter;
+        }
+      }
+    );
+    meters = CacheBuilder.newBuilder().build(
+        new CacheLoader<String, Meter>() {
+          @Override
+          public Meter load(String key) {
+            Meter meter = new Meter();
+            metricRegistry.register(key, meter);
+            return meter;
+          }
+        }
+    );
+    gauges = new ConcurrentHashMap<String, Gauge>();
+
+    //register JVM metrics
+    registerAll("gc", new GarbageCollectorMetricSet());
+    registerAll("buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+    registerAll("memory", new MemoryUsageGaugeSet());
+    registerAll("threads", new ThreadStatesGaugeSet());
+    registerAll("classLoading", new ClassLoadingGaugeSet());
+
+    initCloudwatchReporting();
+  }
+
+
+  @Override
+  public void close() throws Exception {
+    if (reporters != null) {
+      for (Closeable reporter : reporters) {
+        reporter.close();
+      }
+    }
+    for (Map.Entry<String, Metric> metric : metricRegistry.getMetrics().entrySet()) {
+      metricRegistry.remove(metric.getKey());
+    }
+    timers.invalidateAll();
+    counters.invalidateAll();
+    meters.invalidateAll();
+  }
+
+  @Override
+  public void startStoredScope(String name) {
+    if (threadLocalScopes.get().containsKey(name)) {
+      threadLocalScopes.get().get(name).open();
+    } else {
+      threadLocalScopes.get().put(name, new CodahaleMetricsScope(name));
+    }
+  }
+
+  @Override
+  public void endStoredScope(String name) {
+    if (threadLocalScopes.get().containsKey(name)) {
+      threadLocalScopes.get().get(name).close();
+      threadLocalScopes.get().remove(name);
+    }
+  }
+
+  public MetricsScope getStoredScope(String name) throws IllegalArgumentException {
+    if (threadLocalScopes.get().containsKey(name)) {
+      return threadLocalScopes.get().get(name);
+    } else {
+      throw new IllegalArgumentException("No metrics scope named " + name);
+    }
+  }
+
+  public MetricsScope createScope(String name) {
+    return new CodahaleMetricsScope(name);
+  }
+
+  public void endScope(MetricsScope scope) {
+    ((CodahaleMetricsScope) scope).close();
+  }
+
+  @Override
+  public Long incrementCounter(String name) {
+    return incrementCounter(name, 1L);
+  }
+
+  @Override
+  public Long incrementCounter(String name, long increment) {
+    String key = name;
+    try {
+      countersLock.lock();
+      counters.get(key).inc(increment);
+      return counters.get(key).getCount();
+    } catch(ExecutionException ee) {
+      throw new IllegalStateException("Error retrieving counter from the metric registry ", ee);
+    } finally {
+      countersLock.unlock();
+    }
+  }
+
+  @Override
+  public Long decrementCounter(String name) {
+    return decrementCounter(name, 1L);
+  }
+
+  @Override
+  public Long decrementCounter(String name, long decrement) {
+    String key = name;
+    try {
+      countersLock.lock();
+      counters.get(key).dec(decrement);
+      return counters.get(key).getCount();
+    } catch(ExecutionException ee) {
+      throw new IllegalStateException("Error retrieving counter from the metric registry ", ee);
+    } finally {
+      countersLock.unlock();
+    }
+  }
+
+  @Override
+  public void addGauge(String name, final MetricsVariable variable) {
+    Gauge gauge = new Gauge() {
+      @Override
+      public Object getValue() {
+        return variable.getValue();
+      }
+    };
+    addGaugeInternal(name, gauge);
+  }
+
+  @Override
+  public void addRatio(String name, MetricsVariable<Integer> numerator,
+                           MetricsVariable<Integer> denominator) {
+    Preconditions.checkArgument(numerator != null, "Numerator must not be null");
+    Preconditions.checkArgument(denominator != null, "Denominator must not be null");
+
+    MetricVariableRatioGauge gauge = new MetricVariableRatioGauge(numerator, denominator);
+    addGaugeInternal(name, gauge);
+  }
+
+  private void addGaugeInternal(String name, Gauge gauge) {
+    try {
+      gaugesLock.lock();
+      gauges.put(name, gauge);
+      // Metrics throws an Exception if we don't do this when the key already exists
+      if (metricRegistry.getGauges().containsKey(name)) {
+        LOGGER.warn("A Gauge with name [" + name + "] already exists. "
+            + " The old gauge will be overwritten, but this is not recommended");
+        metricRegistry.remove(name);
+      }
+      metricRegistry.register(name, gauge);
+    } finally {
+      gaugesLock.unlock();
+    }
+  }
+
+  @Override
+  public void markMeter(String name) {
+    String key = name;
+    try {
+      metersLock.lock();
+      Meter meter = meters.get(name);
+      meter.mark();
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("Error retrieving meter " + name
+          + " from the metric registry ", e);
+    } finally {
+      metersLock.unlock();
+    }
+  }
+
+  // This method is necessary to synchronize lazy-creation to the timers.
+  private Timer getTimer(String name) {
+    String key = name;
+    try {
+      timersLock.lock();
+      Timer timer = timers.get(key);
+      return timer;
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("Error retrieving timer " + name
+          + " from the metric registry ", e);
+    } finally {
+      timersLock.unlock();
+    }
+  }
+
+  private void registerAll(String prefix, MetricSet metricSet) {
+    for (Map.Entry<String, Metric> entry : metricSet.getMetrics().entrySet()) {
+      if (entry.getValue() instanceof MetricSet) {
+        registerAll(prefix + "." + entry.getKey(), (MetricSet) entry.getValue());
+      } else {
+        metricRegistry.register(prefix + "." + entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public MetricRegistry getMetricRegistry() {
+    return metricRegistry;
+  }
+
+  @VisibleForTesting
+  public String dumpJson() throws Exception {
+    ObjectMapper jsonMapper = new ObjectMapper().registerModule(
+      new MetricsModule(TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS, false));
+    return jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(metricRegistry);
+  }
+
+  private void initCloudwatchReporting() {
+    final CloudwatchReporter cloudwatchReporter = new CloudwatchReporter();
+    cloudwatchReporter.start();
+    reporters.add(cloudwatchReporter);
+  }
+
+  class CloudwatchReporter implements Closeable {
+    private ObjectMapper jsonMapper = null;
+    private java.util.Timer timer = null;
+    private AmazonCloudWatch cw = null;
+
+    public void start() {
+      this.cw = AmazonCloudWatchClientBuilder.defaultClient();
+      this.timer = new java.util.Timer(true);
+
+      timer.schedule(new TimerTask() {
+        @Override
+        public void run() {
+            String namespace = System.getenv("CLOUDWATCH_NAMESPACE");
+            Dimension dimension = new Dimension().withName("ecsTaskId") .withValue(System.getenv("ECS_TASK_ID"));
+            //all interested metrics are gauges so only writing those to cloudwatch
+            for (Map.Entry<String,Gauge> entry : metricRegistry.getGauges().entrySet()) {
+                try 
+                {
+                    String metricName = entry.getKey();
+                    Double metricValue;
+                    if(entry.getValue().getValue() instanceof Long)
+                    {
+                        metricValue = ((Long)(entry.getValue().getValue())).doubleValue();
+                    }
+                    else if(entry.getValue().getValue() instanceof Integer)
+                    {
+                        metricValue = ((Integer)(entry.getValue().getValue())).doubleValue();
+                    }
+                    else
+                    {
+                        metricValue = (double)entry.getValue().getValue();
+                    }
+                    MetricDatum datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.None).withValue(metricValue).withDimensions(dimension);
+                    PutMetricDataRequest request = new PutMetricDataRequest().withNamespace(namespace) .withMetricData(datum);
+                    PutMetricDataResult response = cw.putMetricData(request);
+                } catch (Exception e) {
+                    //ignore threads.deadlocks collection
+                }
+            }
+        }
+      }, 0, 60000); //write to cloudwatch every minute
+    }
+
+    @Override
+    public void close() {
+      if (timer != null) {
+        this.timer.cancel();
+      }
+    }
+  }
+
+}

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * copied from https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/metrics2/TestCodahaleMetrics.java
+ * removed testFileReporting
+ */
 package com.expedia.apiary.extensions.metastore.metrics;
 
 import com.codahale.metrics.Counter;

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for new Metrics subsystem.
  */
-public class TestCodahaleMetrics {
+public class CodahaleMetricsTest {
 
   public static MetricRegistry metricRegistry;
 

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
@@ -15,8 +15,9 @@
  */
 
 /**
+ * Contains code from the Apache Hive project, specifically:
  * copied from https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/metrics2/TestCodahaleMetrics.java
- * removed testFileReporting
+ * removed testFileReporting(), added some code to set System Environment Variables
  */
 package com.expedia.apiary.extensions.metastore.metrics;
 
@@ -33,7 +34,9 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -50,10 +53,16 @@ import static org.junit.Assert.assertTrue;
  */
 public class CodahaleMetricsTest {
 
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
   public static MetricRegistry metricRegistry;
 
   @Before
   public void before() throws Exception {
+    environmentVariables.set("CLOUDWATCH_NAMESPACE", "some-cloud-watch-namespace");
+    environmentVariables.set("ECS_TASK_ID", "some-task-id");
+
     HiveConf conf = new HiveConf();
 
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, "local");

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * copied from: https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/MetricsTestUtils.java
+ */
+
 package com.expedia.apiary.extensions.metastore.metrics;
 
 import com.codahale.metrics.Meter;

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
@@ -15,9 +15,9 @@
  */
 
 /**
- * copied from: https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/MetricsTestUtils.java
+ * Contains code from the Apache Hive project, specifically: 
+ * https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/MetricsTestUtils.java
  */
-
 package com.expedia.apiary.extensions.metastore.metrics;
 
 import com.codahale.metrics.Meter;

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/MetricsTestUtils.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.apiary.extensions.metastore.metrics;
+
+import com.codahale.metrics.Meter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Utilities for codahale metrics verification.
+ */
+public class MetricsTestUtils {
+
+  public static final MetricsCategory COUNTER = new MetricsCategory("counters", "count");
+  public static final MetricsCategory TIMER = new MetricsCategory("timers", "count");
+  public static final MetricsCategory GAUGE = new MetricsCategory("gauges", "value");
+  public static final MetricsCategory METER = new MetricsCategory("meters", "count");
+
+  static class MetricsCategory {
+    String category;
+    String metricsHandle;
+    MetricsCategory(String category, String metricsHandle) {
+      this.category = category;
+      this.metricsHandle = metricsHandle;
+    }
+  }
+
+  public static void verifyMetricsJson(String json, MetricsCategory category, String metricsName,
+    Object expectedValue) throws Exception {
+    JsonNode jsonNode = getJsonNode(json, category, metricsName);
+    Assert.assertEquals(expectedValue.toString(), jsonNode.asText());
+  }
+
+  public static void verifyMetricsJson(String json, MetricsCategory category, String metricsName,
+                                           Double expectedValue, Double delta) throws Exception {
+    JsonNode jsonNode = getJsonNode(json, category, metricsName);
+    Assert.assertEquals(expectedValue, Double.valueOf(jsonNode.asText()), delta);
+  }
+
+  public static JsonNode getJsonNode(String json, MetricsCategory category, String metricsName) throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode rootNode = objectMapper.readTree(json);
+    JsonNode categoryNode = rootNode.path(category.category);
+    JsonNode metricsNode = categoryNode.path(metricsName);
+    return metricsNode.path(category.metricsHandle);
+  }
+
+  public static byte[] getFileData(String path, int timeoutInterval, int tries) throws Exception {
+    File file = new File(path);
+    do {
+      Thread.sleep(timeoutInterval);
+      tries--;
+    } while (tries > 0 && !file.exists());
+    return Files.readAllBytes(Paths.get(path));
+  }
+}

--- a/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/TestCodahaleMetrics.java
+++ b/apiary-metastore-metrics/src/test/java/com/expedia/apiary/extensions/metastore/metrics/TestCodahaleMetrics.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.apiary.extensions.metastore.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+//import org.apache.hadoop.hive.common.metrics.MetricsTestUtils;
+import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
+import org.apache.hadoop.hive.common.metrics.common.MetricsVariable;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for new Metrics subsystem.
+ */
+public class TestCodahaleMetrics {
+
+  public static MetricRegistry metricRegistry;
+
+  @Before
+  public void before() throws Exception {
+    HiveConf conf = new HiveConf();
+
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, "local");
+    conf.setVar(HiveConf.ConfVars.HIVE_METRICS_CLASS, CodahaleMetrics.class.getCanonicalName());
+
+    MetricsFactory.init(conf);
+    metricRegistry = ((CodahaleMetrics) MetricsFactory.getInstance()).getMetricRegistry();
+  }
+
+  @After
+  public void after() throws Exception {
+    MetricsFactory.close();
+  }
+
+  @Test
+  public void testScope() throws Exception {
+    int runs = 5;
+    for (int i = 0; i < runs; i++) {
+      MetricsFactory.getInstance().startStoredScope("method1");
+      MetricsFactory.getInstance().endStoredScope("method1");
+    }
+
+    Timer timer = metricRegistry.getTimers().get("method1");
+    Assert.assertEquals(5, timer.getCount());
+    Assert.assertTrue(timer.getMeanRate() > 0);
+  }
+
+
+  @Test
+  public void testCount() throws Exception {
+    int runs = 5;
+    for (int i = 0; i < runs; i++) {
+      MetricsFactory.getInstance().incrementCounter("count1");
+    }
+    Counter counter = metricRegistry.getCounters().get("count1");
+    Assert.assertEquals(5L, counter.getCount());
+  }
+
+  @Test
+  public void testConcurrency() throws Exception {
+    int threads = 4;
+    ExecutorService executorService = Executors.newFixedThreadPool(threads);
+    for (int i=0; i< threads; i++) {
+      final int n = i;
+      executorService.submit(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          MetricsFactory.getInstance().startStoredScope("method2");
+          MetricsFactory.getInstance().endStoredScope("method2");
+          return null;
+        }
+      });
+    }
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(10000, TimeUnit.MILLISECONDS));
+    Timer timer = metricRegistry.getTimers().get("method2");
+    Assert.assertEquals(4, timer.getCount());
+    Assert.assertTrue(timer.getMeanRate() > 0);
+  }
+
+  class TestMetricsVariable implements MetricsVariable {
+    private int gaugeVal;
+
+    @Override
+    public Object getValue() {
+      return gaugeVal;
+    }
+    public void setValue(int gaugeVal) {
+      this.gaugeVal = gaugeVal;
+    }
+  };
+
+  @Test
+  public void testGauge() throws Exception {
+    TestMetricsVariable testVar = new TestMetricsVariable();
+    testVar.setValue(20);
+
+    MetricsFactory.getInstance().addGauge("gauge1", testVar);
+    String json = ((CodahaleMetrics) MetricsFactory.getInstance()).dumpJson();
+    MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.GAUGE, "gauge1", testVar.getValue());
+
+
+    testVar.setValue(40);
+    json = ((CodahaleMetrics) MetricsFactory.getInstance()).dumpJson();
+    MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.GAUGE, "gauge1", testVar.getValue());
+  }
+
+  @Test
+  public void testMeter() throws Exception {
+
+    String json = ((CodahaleMetrics) MetricsFactory.getInstance()).dumpJson();
+    MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.METER, "meter", "");
+
+    MetricsFactory.getInstance().markMeter("meter");
+    json = ((CodahaleMetrics) MetricsFactory.getInstance()).dumpJson();
+    MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.METER, "meter", "1");
+
+    MetricsFactory.getInstance().markMeter("meter");
+    json = ((CodahaleMetrics) MetricsFactory.getInstance()).dumpJson();
+    MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.METER, "meter", "2");
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <module>apiary-metastore-listener</module>
     <module>apiary-gluesync-listener</module>
     <module>apiary-ranger-metastore-plugin</module>
+    <module>apiary-metastore-metrics</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
This is mostly based on following, just added CloudwatchReporter nested class
https://github.com/apache/hive/blob/branch-2.3/common/src/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
https://github.com/apache/hive/blob/branch-2.3/common/src/test/org/apache/hadoop/hive/common/metrics/metrics2/TestCodahaleMetrics.java

Note: hive 3.0.0 natively supports custom classes for reporters, so this will be simpler when we move to hive 3.0.0
https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-Metrics


