### PR TITLE
Fixing JSON Response from Apiary Hive Metastore Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - TBD
+### Fixed
+- JSON Events from ApiarySNSListener now marshals list as a JSONArray.
+
 ## [0.2.0] - 2018-10-03
 ### Added
 - `apiary-gluesync-listener` sub-module.

--- a/apiary-gluesync-listener/pom.xml
+++ b/apiary-gluesync-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expedia.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-gluesync-listener</artifactId>

--- a/apiary-metastore-listener/README.md
+++ b/apiary-metastore-listener/README.md
@@ -83,7 +83,7 @@ The following shows an example JSON message representing an "ADD_PARTITION" even
       "eventType": "ADD_PARTITION",
       "dbName": "some_db",
       "tableName": "some_table",
-      "partition": "[col_1, col_2, col_3]"
+      "partition": ["col_1", "col_2", "col_3"]
     }
 
 #### Drop Partition
@@ -94,7 +94,7 @@ The following shows an example JSON message representing a "DROP_PARTITION" even
       "eventType": "DROP_PARTITION",
       "dbName": "some_db",
       "tableName": "some_table",
-      "partition": "[col_1, col_2, col_3]"
+      "partition": ["col_1", "col_2", "col_3"]
     }
 
 #### Alter Partition
@@ -105,8 +105,8 @@ The following shows an example JSON message representing an "ALTER_PARTITION" ev
       "eventType": "ALTER_PARTITION",
       "dbName": "some_db",
       "tableName": "some_table",
-      "partition": "[col_1,col_2]",
-      "oldPartition": "[col_1,col_2,col_3]"
+      "partition": ["col_1","col_2"],
+      "oldPartition": ["col_1", "col_2", "col_3"]
     }
 
 # Legal

--- a/apiary-metastore-listener/pom.xml
+++ b/apiary-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expedia.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-listener</artifactId>

--- a/apiary-metastore-listener/src/main/java/com/expedia/apiary/extensions/metastore/listener/ApiarySnsListener.java
+++ b/apiary-metastore-listener/src/main/java/com/expedia/apiary/extensions/metastore/listener/ApiarySnsListener.java
@@ -147,10 +147,12 @@ public class ApiarySnsListener extends MetaStoreEventListener {
       json.put("oldTableName", oldtable.getTableName());
     }
     if (partition != null) {
-      json.put("partition", partition.getValues());
+      JSONArray partitionValuesArray = new JSONArray(partition.getValues());
+      json.put("partition", partitionValuesArray);
     }
     if (oldpartition != null) {
-      json.put("oldPartition", oldpartition.getValues());
+      JSONArray partitionValuesArray = new JSONArray(oldpartition.getValues());
+      json.put("oldPartition", partitionValuesArray);
     }
 
     sendMessage(json);

--- a/apiary-metastore-listener/src/test/java/com/expedia/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
+++ b/apiary-metastore-listener/src/test/java/com/expedia/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
@@ -144,7 +144,7 @@ public class ApiarySnsListenerTest {
 
     assertThat(publishRequest.getMessage(), is("{\"protocolVersion\":\""
         + PROTOCOL_VERSION
-        + "\",\"eventType\":\"ADD_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":\"[col_1, col_2, col_3]\"}"));
+        + "\",\"eventType\":\"ADD_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":[\"col_1\",\"col_2\",\"col_3\"]}"));
   }
 
   @Test
@@ -170,7 +170,7 @@ public class ApiarySnsListenerTest {
 
     assertThat(publishRequest.getMessage(), is("{\"protocolVersion\":\""
         + PROTOCOL_VERSION
-        + "\",\"eventType\":\"DROP_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":\"[col_1, col_2, col_3]\"}"));
+        + "\",\"eventType\":\"DROP_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":[\"col_1\",\"col_2\",\"col_3\"]}"));
   }
 
   @Test
@@ -217,7 +217,7 @@ public class ApiarySnsListenerTest {
 
     assertThat(publishRequest.getMessage(), is("{\"protocolVersion\":\""
         + PROTOCOL_VERSION
-        + "\",\"eventType\":\"ALTER_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":\"[col_1, col_2]\",\"oldPartition\":\"[col_1, col_2, col_3]\"}"));
+        + "\",\"eventType\":\"ALTER_PARTITION\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"partition\":[\"col_1\",\"col_2\"],\"oldPartition\":[\"col_1\",\"col_2\",\"col_3\"]}"));
   }
 
   @Test

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expedia.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-metrics</artifactId>

--- a/apiary-ranger-metastore-plugin/pom.xml
+++ b/apiary-ranger-metastore-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expedia.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-ranger-metastore-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.expedia.apiary</groupId>
   <artifactId>apiary-extensions-parent</artifactId>
   <description>Various extensions to Apiary that provide additional, optional functionality</description>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apiary Extensions Parent</name>
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
The JSON Response from the Listener marshals the Array as a String which is not ideal and requires unnecessary processing on the receiver side.