### PR TITLE
Remove dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## TBD
+### Removed
+- `aws-java-sdk` dependency from `apiary-receiver-sqs`.
+
 ## [1.4.0] - 2019-03-27
 ### Added
 - `apiary-receivers` parent module and `apiary-receiver-sqs` sub-module, a library to poll Apiary SQS messaging infrastructure for Hive events.

--- a/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -27,11 +27,6 @@
     <!-- AWS -->
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>${aws.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sqs</artifactId>
       <version>${aws.version}</version>
     </dependency>


### PR DESCRIPTION
Removing dependency of entire AWS java sdk from `apiary-receiver-sqs`.